### PR TITLE
Add Glycerine Viewer to the list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,7 @@ As defined by Wikipedia a shim is a small library that transparently intercepts 
 - [Chronoscope World](https://mprove.de/chronoscope/world.html) – A viewer for georeferenced IIIF maps. It is also a fast viewer for browsing IIIF books.
 - [Clover IIIF](https://samvera-labs.github.io/clover-iiif/) - IIIF Presentation API Manifest viewer handling Image, Sound, and Video canvases for React.js
 - [Diva.js](https://ddmal.github.io/diva.js/) - IIIF image viewer optimized for speed and flexibility.
+- [Glycerine Viewer](https://github.com/Systemik-Solutions/glycerine-viewer) - An elegant a contemporary Vue 3 Viewer with a comprehensive annotation feature set.
 - [IIIF Curation Viewer](http://codh.rois.ac.jp/software/iiif-curation-viewer/) - A general IIIF viewer with added focus on curation and ordering of cropped IIIF images. [Demo](http://codh.rois.ac.jp/software/iiif-curation-viewer/demo/?curation=https://gist.githubusercontent.com/2SC1815J/18e1228c52a6650c64902142ed7496f8/raw/7a247b64b6e22357e83f573b7283e31f3111af68/curation_kibutsu.json&pos=4)
 - [Internet Archive BookReader](https://github.com/internetarchive/bookreader) - A viewer developed by the Internet Archive, specially suited for viewing books.
 - [Micrio](https://micr.io/iiif) - High-performance client with WebAssembly/WebGL engine and additional storytelling elements. Also offering full server IIIF support.


### PR DESCRIPTION
Initially designed for the sophisticated annotation features of Glycerine Workbench, [Glycerine Viewer](https://github.com/Systemik-Solutions/glycerine-viewer) has been released as an open source IIIF viewer to support IIIF manifests and compliant annotations built with other tools. Developed with a contemporary Vue 3 framework, Glycerine Viewer has an elegant interface, supports the IIIF Presentation API and provides the most comprehensive annotation feature set of any IIIF Viewer.